### PR TITLE
Use Gatsby command instead of cloning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Edith is a free and open source learning platform based on [Gatsby](https://www.
 1. **Get the code**.
 
    ```
-   git clone https://github.com/marcusolsson/edith.git
+   gatsby new my-site https://github.com/marcusolsson/edith.git
    ```
 
 1. **Start the site in develop mode**.
 
    ```
-   cd edith
+   cd my-site
    yarn workspace www develop
    ```
 


### PR DESCRIPTION
Using the Gatsby command causes the git history to reset, which might be preferable. This is also the way mentioned in Gatsby docs.