### PR TITLE
CI: Publish using GITHUB_TOKEN

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PERSONAL_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
@@ -28,5 +28,5 @@ jobs:
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./www/public


### PR DESCRIPTION
Everybody has access to a GITHUB_TOKEN, which means publishing can be done without configuring tokens.

https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token